### PR TITLE
add dry run feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ yarn
 | PRIVATE_KEY    | null                                       | The private key of the admin wallet added within the deployed FluxAggregator.sol contracts, used to send the withdraw transactions. |
 | WITHDRAW_TO    | null                                       | The Ethereum address to withdraw the earned LINK to.                                                                                |
 | GAS_PRICE      | 20000000000                                | The gas price in wei to use when sending the withdraw transactions.                                                                 |
+| DRY_RUN        | null                                       | Simulate withdrawal, but skip performing transactions.
 
 ### Run Locally
 

--- a/withdraw.ts
+++ b/withdraw.ts
@@ -11,6 +11,7 @@ const walletAddress = process.env.WALLET_ADDRESS || "0x501698a6f6f762c79e4d28e38
 const rpcUrl = process.env.RPC_URL || "http://localhost:8545"
 const privateKey = process.env.PRIVATE_KEY || ""
 const withdrawTo = process.env.WITHDRAW_TO || ""
+const dryRun = process.env.DRY_RUN || ""
 
 const gasPrice = process.env.GAS_PRICE || 20000000000 // 20 Gwei
 const txOptions = {gasPrice: gasPrice}
@@ -50,7 +51,11 @@ async function withdrawFromFeed(feed: Feed, wallet: ethers.Wallet) {
     const feedContract = new ethers.Contract(feed.contractAddress.toString(), fluxAggregatorAbi, wallet)
     const withdrawableAmount = await feedContract.withdrawablePayment(walletAddress)
     log.info("Withdrawing amount " + ethers.utils.formatEther(withdrawableAmount) + " LINK from feed " + feed.contractAddress + ", to " + withdrawTo)
-    await feedContract.withdrawPayment(walletAddress, withdrawTo, withdrawableAmount, txOptions)
+    if (dryRun) {
+      log.debug("Dry run, skipping withdrawal")
+    } else {
+      await feedContract.withdrawPayment(walletAddress, withdrawTo, withdrawableAmount, txOptions)
+    }
 }
 
 async function run() {


### PR DESCRIPTION
Pretty small change, but I found myself commenting out the `feedContract.withdrawPayment` so I could see what I had available to withdraw before I actually spent the gas on it. I figured it would be cleaner just to add the feature so I didn't have to muck with the code.

